### PR TITLE
Normal vector and rotation angle computation

### DIFF
--- a/character/Character.js
+++ b/character/Character.js
@@ -25,12 +25,22 @@ class Character {
 
     /**
      * Draws the beautiful box guy.
+     * @param {{object: Ground, args: any}} ground The ground below the character.
      */
-    draw() {
+    draw(ground) {
+        let rotationAngle = ground.object.getRotationAt(this.#x);
+        
         ctx.globalCompositeOperation = "soft-light";
         ctx.fillStyle = "white";
-        ctx.fillRect(this.#x - 10, this.#y, 20, 50)
-        ctx.globalCompositeOperation = "source-over"
+
+        ctx.translate(this.#x, this.#y + 50);
+        ctx.rotate(rotationAngle);
+        ctx.translate(-this.#x, -this.#y - 50);
+
+        ctx.fillRect(this.#x - 10, this.#y, 20, 50);
+
+        ctx.setTransform(1, 0, 0, 1, 0, 0);
+        ctx.globalCompositeOperation = "source-over";
     }
 
     /**

--- a/graphics/Renderer.js
+++ b/graphics/Renderer.js
@@ -161,7 +161,7 @@ class Renderer {
         for (let character of this.#charactersPipeline) {
             character.update();
             character.clip(this.#groundPipeline[0]);
-            character.draw();
+            character.draw(this.#groundPipeline[0]);
         }
 
         // Render the ground pipeline.

--- a/map/Ground.js
+++ b/map/Ground.js
@@ -9,6 +9,7 @@ class Ground {
     #yLimit;
 
     #interpolationFunction;
+    #rotationFunction;
 
     /**
      * Create a ground object
@@ -25,10 +26,11 @@ class Ground {
         this.#yLimit = inverted ? Math.min(pointA[1], pointB[1]) : Math.max(pointA[1], pointB[1]);
 
         this.#interpolationFunction = this.#getInterpolationFunction(interpolationType);
+        this.#rotationFunction = this.#getRotationFunction(interpolationType);
     }
 
     /**
-     * 
+     * Gets the interpolation function for the corresponding type.
      * @param {"lerp"|"steps"|"cubic"|"smoother"} interpolationType The interpolation function we want to use.
      * @returns {function} The correct interpolation function.
      */
@@ -44,6 +46,26 @@ class Ground {
         }
         if (interpolationType == "smoother") {
             return this.#ys.smoother;
+        }
+    }
+
+    /**
+     * Gets the rotation function for the corresponding type.
+     * @param {"lerp"|"steps"|"cubic"|"smoother"} interpolationType The interpolation function we want to use.
+     * @returns {function} The correct rotation function.
+     */
+    #getRotationFunction(interpolationType) {
+        if (interpolationType == "lerp") {
+            return this.#ys.lerpRotation;
+        }
+        if (interpolationType == "steps") {
+            return this.#ys.stepsRotation;
+        }
+        if (interpolationType == "cubic") {
+            return this.#ys.cubicRotation;
+        }
+        if (interpolationType == "smoother") {
+            return this.#ys.smootherRotation;
         }
     }
 
@@ -77,5 +99,15 @@ class Ground {
         } else {
             return this.#interpolationFunction.apply(this.#ys, [t]);
         }
+    }
+
+    /**
+     * Give the rotation vector at a provided x.
+     * @param {number} x The x coordinate we want to compute the rotation vector at.
+     */
+    getRotationAt(x) {
+        let t = (x - this.#xa) / (this.#xb - this.#xa);
+
+        return this.#rotationFunction.apply(this.#ys, [t, this.#xb - this.#xa]);
     }
 }

--- a/map/Interpolation.js
+++ b/map/Interpolation.js
@@ -85,6 +85,7 @@ class Interpolation {
     /**
      * Get the rotation angle (using the normal vector) for a linear interpolation between a and b.
      * @param {number} t The interpolation parameter (between 0 and 1).
+     * @param {number} xLength The ground length in terms of X.
      * @returns {number} The rotation angle at t.
      * 
      * @see https://en.wikipedia.org/wiki/Linear_interpolation
@@ -99,6 +100,7 @@ class Interpolation {
     /**
      * Get the rotation angle (using the normal vector) for a stepped linear interpolation between a and b.
      * @param {number} t The interpolation parameter (between 0 and 1).
+     * @param {number} xLength The ground length in terms of X.
      * @returns {number} The rotation angle at t.
      * 
      * @see https://en.wikipedia.org/wiki/Linear_interpolation
@@ -111,6 +113,7 @@ class Interpolation {
     /**
      * Get the rotation angle (using the normal vector) for a cubic interpolation between a and b.
      * @param {number} t The interpolation parameter (between 0 and 1).
+     * @param {number} xLength The ground length in terms of X.
      * @returns {number} The rotation angle at t.
      * 
      * @see https://en.wikipedia.org/wiki/Smoothstep
@@ -125,6 +128,7 @@ class Interpolation {
     /**
      * Get the rotation angle (using the normal vector) for a quintic interpolation between a and b.
      * @param {number} t The interpolation parameter (between 0 and 1).
+     * @param {number} xLength The ground length in terms of X.
      * @returns {number} The rotation angle at t.
      * 
      * @see https://en.wikipedia.org/wiki/Smoothstep

--- a/map/Interpolation.js
+++ b/map/Interpolation.js
@@ -71,7 +71,7 @@ class Interpolation {
     /**
      * Performs quintic interpolation between a and b.
      * @param {number} t The interpolation parameter (between 0 and 1).
-     * @return {number} The interpolated point at t.
+     * @returns {number} The interpolated point at t.
      * 
      * @see https://en.wikipedia.org/wiki/Smoothstep
      */
@@ -80,5 +80,59 @@ class Interpolation {
         if (t > 1) return this.#b;
 
         return (this.#b - this.#a) * (t * (t * 6 - 15) + 10) * t * t * t + this.#a;
+    }
+
+    /**
+     * Get the rotation angle (using the normal vector) for a linear interpolation between a and b.
+     * @param {number} t The interpolation parameter (between 0 and 1).
+     * @returns {number} The rotation angle at t.
+     * 
+     * @see https://en.wikipedia.org/wiki/Linear_interpolation
+     */
+    lerpRotation(t, xLength) {
+        if (t < 0 || t > 1) return 0;
+
+        let derivative = this.#b - this.#a;
+        return 1.5 * Math.PI + Math.acos(-derivative / Math.sqrt(derivative * derivative + xLength * xLength));
+    }
+
+    /**
+     * Get the rotation angle (using the normal vector) for a stepped linear interpolation between a and b.
+     * @param {number} t The interpolation parameter (between 0 and 1).
+     * @returns {number} The rotation angle at t.
+     * 
+     * @see https://en.wikipedia.org/wiki/Linear_interpolation
+     * @see https://en.wikipedia.org/wiki/Floor_and_ceiling_functions
+     */
+    stepsRotation(t, xLength) {
+        return 0;
+    }
+
+    /**
+     * Get the rotation angle (using the normal vector) for a cubic interpolation between a and b.
+     * @param {number} t The interpolation parameter (between 0 and 1).
+     * @returns {number} The rotation angle at t.
+     * 
+     * @see https://en.wikipedia.org/wiki/Smoothstep
+     */
+    cubicRotation(t, xLength) {
+        if (t < 0 || t > 1) return 0;
+    
+        let derivative = (this.#b - this.#a) * 6 * (t - t * t);
+        return 1.5 * Math.PI + Math.acos(-derivative / Math.sqrt(derivative * derivative + xLength * xLength));
+    }
+
+    /**
+     * Get the rotation angle (using the normal vector) for a quintic interpolation between a and b.
+     * @param {number} t The interpolation parameter (between 0 and 1).
+     * @returns {number} The rotation angle at t.
+     * 
+     * @see https://en.wikipedia.org/wiki/Smoothstep
+     */
+    smootherRotation(t, xLength) {
+        if (t < 0 || t > 1) return 0;
+
+        let derivative = (this.#b - this.#a) * 30 * (t - t * t) * (t - t * t);
+        return 1.5 * Math.PI + Math.acos(-derivative / Math.sqrt(derivative * derivative + xLength * xLength));
     }
 }


### PR DESCRIPTION
# Rotation angle calculation

The [`ground`](map/Ground.js) objects can now be used to compute the rotation angle needed by the rendering context to align the characters to the normal vector at any given point.

Given the rendering axes and an interpolation function $\mathbf f$, the angle of rotation $\theta$ at interpolation parameter $t$ is given by the following formula : 
$$\theta(t) = \frac{3 \pi}{2} + \arccos \left( -\frac{\mathbf f'(t)}{\sqrt{\mathbf f'(t)^2 + \Delta  x^2}} \right)$$
Where : 
$$-\frac{\mathbf f'(t)}{\sqrt{\mathbf f'(t)^2 + \Delta  x^2}} = \frac{ \left < \mathbf n(t), \hat \imath \right >}{\|\|\mathbf n(t)\|\|} = \theta{\mathbf n \hat\imath}$$

Chance is that we know the formulae for the interpolation functions $\mathbf f$, so $\mathbf f'$ is well known.